### PR TITLE
Fix parsing of floating numbers

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -145,9 +145,9 @@ if (typeof Path2D !== 'function') {
                   ellipseFromEllipticalArc.apply(this, absArgs);
                 }
               },
-            peg$c37 = function(rx, ry, xrot, large, sweep, last) { return [parseFloat(rx), parseFloat(ry), parseFloat(xrot.join('')), parseInt(large), parseInt(sweep), last[0], last[1]]; },
+            peg$c37 = function(rx, ry, xrot, large, sweep, last) { return [parseFloat(rx), parseFloat(ry), parseFloat(flatten(xrot).join('')), parseInt(large), parseInt(sweep), last[0], last[1]]; },
             peg$c38 = function(x, y) { return [x, y] },
-            peg$c39 = function(number) { return parseFloat(number.join('')) },
+            peg$c39 = function(number) { return parseFloat(flatten(number).join('')) },
             peg$c40 = "0",
             peg$c41 = { type: "literal", value: "0", description: "\"0\"" },
             peg$c42 = "1",
@@ -1892,7 +1892,21 @@ if (typeof Path2D !== 'function') {
           var firstSubPath = true;
           // The letter of the last parsed command.
           var lastCh = '';
-    
+
+          // Flatten an array.
+          function flatten(a) {
+            var flat = [];
+            for (var i = 0; i < a.length; i++) {
+              if (a[i] instanceof Array) {
+                flat.push.apply(flat, flatten(a[i]));
+              }
+              else {
+                flat.push(a[i]);
+              }
+            }
+            return flat;
+          }
+
           // Convert a position into an absolute position.
           function makeAbsolute(c, coord) {
             if ('mlazhvcsqt'.indexOf(c) === -1) {

--- a/canvas.js
+++ b/canvas.js
@@ -1899,8 +1899,7 @@ if (typeof Path2D !== 'function') {
             for (var i = 0; i < a.length; i++) {
               if (a[i] instanceof Array) {
                 flat.push.apply(flat, flatten(a[i]));
-              }
-              else {
+              } else {
                 flat.push(a[i]);
               }
             }

--- a/svgpath.js
+++ b/svgpath.js
@@ -1873,8 +1873,7 @@ parser = (function() {
         for (var i = 0; i < a.length; i++) {
           if (a[i] instanceof Array) {
             flat.push.apply(flat, flatten(a[i]));
-          }
-          else {
+          } else {
             flat.push(a[i]);
           }
         }

--- a/svgpath.js
+++ b/svgpath.js
@@ -119,9 +119,9 @@ parser = (function() {
               ellipseFromEllipticalArc.apply(this, absArgs);
             }
           },
-        peg$c37 = function(rx, ry, xrot, large, sweep, last) { return [parseFloat(rx), parseFloat(ry), parseFloat(xrot.join('')), parseInt(large), parseInt(sweep), last[0], last[1]]; },
+        peg$c37 = function(rx, ry, xrot, large, sweep, last) { return [parseFloat(rx), parseFloat(ry), parseFloat(flatten(xrot).join('')), parseInt(large), parseInt(sweep), last[0], last[1]]; },
         peg$c38 = function(x, y) { return [x, y] },
-        peg$c39 = function(number) { return parseFloat(number.join('')) },
+        peg$c39 = function(number) { return parseFloat(flatten(number).join('')) },
         peg$c40 = "0",
         peg$c41 = { type: "literal", value: "0", description: "\"0\"" },
         peg$c42 = "1",
@@ -1866,6 +1866,20 @@ parser = (function() {
       var firstSubPath = true;
       // The letter of the last parsed command.
       var lastCh = '';
+
+      // Flatten an array.
+      function flatten(a) {
+        var flat = [];
+        for (var i = 0; i < a.length; i++) {
+          if (a[i] instanceof Array) {
+            flat.push.apply(flat, flatten(a[i]));
+          }
+          else {
+            flat.push(a[i]);
+          }
+        }
+        return flat;
+      }
 
       // Convert a position into an absolute position.
       function makeAbsolute(c, coord) {

--- a/svgpath.pegjs
+++ b/svgpath.pegjs
@@ -26,8 +26,7 @@
     for (var i = 0; i < a.length; i++) {
       if (a[i] instanceof Array) {
         flat.push.apply(flat, flatten(a[i]));
-      }
-      else {
+      } else {
         flat.push(a[i]);
       }
     }

--- a/svgpath.pegjs
+++ b/svgpath.pegjs
@@ -20,6 +20,20 @@
   // The letter of the last parsed command.
   var lastCh = '';
 
+  // Flatten an array.
+  function flatten(a) {
+    var flat = [];
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] instanceof Array) {
+        flat.push.apply(flat, flatten(a[i]));
+      }
+      else {
+        flat.push(a[i]);
+      }
+    }
+    return flat;
+  }
+
   // Convert a position into an absolute position.
   function makeAbsolute(c, coord) {
     if ('mlazhvcsqt'.indexOf(c) === -1) {
@@ -363,7 +377,7 @@ elliptical_arc_argument_sequence
 elliptical_arc_argument
   = rx:nonnegative_number comma_wsp? ry:nonnegative_number comma_wsp?
         xrot:number comma_wsp large:flag comma_wsp? sweep:flag comma_wsp? last:coordinate_pair
-  { return [parseFloat(rx), parseFloat(ry), parseFloat(xrot.join('')), parseInt(large), parseInt(sweep), last[0], last[1]]; }
+  { return [parseFloat(rx), parseFloat(ry), parseFloat(flatten(xrot).join('')), parseInt(large), parseInt(sweep), last[0], last[1]]; }
 
 coordinate_pair
   = x:coordinate comma_wsp? y:coordinate
@@ -371,7 +385,7 @@ coordinate_pair
 
 coordinate
   = number:number
-  { return parseFloat(number.join('')) }
+  { return parseFloat(flatten(number).join('')) }
 
 nonnegative_number
   = floating_point_constant


### PR DESCRIPTION
@ColaColin reported in issue #2 that floating point numbers are not parsed correctly. The current code is expecting all components of the number in a flatten array (like ['-', '1', '2', '.', '3']) and the parsers returns by default an array for each rule of the grammar, so you get something like [['-'], [['1', '2'], '.', ['3', '4']]].

I flatten the array before we attempt to join it and parse it.
