### PR TITLE
Couple of corner case fixes in ellipseFromEllipticalArc

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -1997,7 +1997,7 @@ if (typeof Path2D !== 'function' ||
             return dot(u,v) / (mag(u)*mag(v))
           }
 
-          function clamp(value,min,max) {
+          function clamp(value, min, max) {
             return Math.min(Math.max(val, min),max);
           }
     

--- a/canvas.js
+++ b/canvas.js
@@ -1996,13 +1996,17 @@ if (typeof Path2D !== 'function' ||
           function ratio(u, v) {
             return dot(u,v) / (mag(u)*mag(v))
           }
+
+          function clamp(value,min,max) {
+            return Math.min(Math.max(val, min),max);
+          }
     
           function angle(u, v) {
             var sign = 1.0;
             if ((u[0]*v[1] - u[1]*v[0]) < 0) {
               sign = -1.0;
             }
-            return sign * Math.acos(ratio(u,v));
+            return sign * Math.acos(clamp(ratio(u,v)), -1, 1);
           }
     
           function rotClockwise(v, angle) {
@@ -2066,8 +2070,7 @@ if (typeof Path2D !== 'function' ||
               rx2 = Math.pow(rx, 2);
               ry2 = Math.pow(ry, 2);
             }
-    
-            var factor = Math.sqrt((rx2*ry2 - rx2*xPrime2[1] - ry2*xPrime2[0]) /
+            var factor = Math.sqrt(Math.abs(rx2*ry2 - rx2*xPrime2[1] - ry2*xPrime2[0]) /
               (rx2*xPrime2[1] + ry2*xPrime2[0]));
             if (fA == fS) {
               factor *= -1.0;


### PR DESCRIPTION
For path data "M100,350 l 50,-25 a25,25 -30 0,1 50,-25 l 50,-25"
Line 2073: argument for Math.sqrt is negative
fix: pass through Math.abs

For path data "M100,350 l 50,-25 a25,75 -30 0,1 50,-25 l 50,-25"
Line 2009: ratio(u,v) is -1.0000000000000002 and hence Math.acos(ratio(u,v)) becomes NaN
fix: a funciton clamp(val, min, max) that clamps the value 'val' between the range [min,max]

"M100,350 l 50,-25 a25,25 -30 0,1 50,-25 l 50,-25"
![firstfix](http://i.imgur.com/dVxhzHY.png)

"M100,350 l 50,-25 a25,75 -30 0,1 50,-25 l 50,-25"
![secondfix](http://i.imgur.com/9frsRn1.png)

Red stroke represents svg render
Black stroke represents Path2D render