### PR TITLE
Typo with clamp

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -2008,7 +2008,7 @@ if (typeof Path2D !== 'function' ||
             if ((u[0]*v[1] - u[1]*v[0]) < 0) {
               sign = -1.0;
             }
-            return sign * Math.acos(clamp(ratio(u,v)), -1, 1);
+            return sign * Math.acos(clamp(ratio(u,v), -1, 1));
           }
     
           function rotClockwise(v, angle) {

--- a/canvas.js
+++ b/canvas.js
@@ -1999,7 +1999,7 @@ if (typeof Path2D !== 'function' ||
             return dot(u,v) / (mag(u)*mag(v))
           }
 
-          function clamp(value, min, max) {
+          function clamp(val, min, max) {
             return Math.min(Math.max(val, min),max);
           }
     


### PR DESCRIPTION
This typo prevents arcs being using in IE,

 _only took 4 years for someone notice 😉_